### PR TITLE
Modernize random generation and code quality improvements

### DIFF
--- a/src/ecs/Systems.hpp
+++ b/src/ecs/Systems.hpp
@@ -3,9 +3,9 @@
 #include "EntityManager.hpp"
 #include "Component.hpp"
 #include "../core/EventBus.hpp"
+#include "../util/Random.hpp"
 #include <SFML/Graphics.hpp>
 #include <cmath>
-#include <cstdlib>
 
 // Physics System - handles movement and room clamping
 class PhysicsSystem {
@@ -74,10 +74,10 @@ private:
         ai->wanderTimer -= dt;
         if (ai->wanderTimer <= 0.f) {
             float interval = ai->behavior == AIBehavior::Erratic ? 0.3f : ai->directionChangeInterval;
-            float angle = static_cast<float>(std::rand()) / RAND_MAX * 2.f * 3.14159f;
+            float angle = util::randomFloat(0.f, 2.f * 3.14159f);
             physics->velocity.x = std::cos(angle) * ai->wanderSpeed;
             physics->velocity.y = std::sin(angle) * ai->wanderSpeed;
-            ai->wanderTimer = interval + static_cast<float>(std::rand()) / RAND_MAX * interval;
+            ai->wanderTimer = interval + util::randomFloat(0.f, interval);
         }
     }
 

--- a/src/game/Floor.hpp
+++ b/src/game/Floor.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "Room.hpp"
+#include "../util/Random.hpp"
 #include <vector>
 #include <memory>
 #include <map>
-#include <cstdlib>
 #include <algorithm>
 
 struct GridPos {
@@ -39,7 +39,7 @@ public:
 
         while (rooms.size() < static_cast<size_t>(roomCount) && !frontier.empty()) {
             // Pick random frontier position
-            int idx = std::rand() % frontier.size();
+            int idx = util::randomInt(0, static_cast<int>(frontier.size()) - 1);
             GridPos pos = frontier[idx];
             frontier.erase(frontier.begin() + idx);
 

--- a/src/game/Room.hpp
+++ b/src/game/Room.hpp
@@ -3,6 +3,7 @@
 #include "../ecs/EntityManager.hpp"
 #include "../ecs/EntityFactory.hpp"
 #include "../core/EventBus.hpp"
+#include "../util/Random.hpp"
 #include <SFML/Graphics.hpp>
 #include <vector>
 #include <functional>
@@ -181,14 +182,14 @@ private:
     }
 
     void spawnEnemies(EntityManager& entities) {
-        int count = minEnemies + (std::rand() % (maxEnemies - minEnemies + 1));
+        int count = util::randomInt(minEnemies, maxEnemies);
 
         for (int i = 0; i < count; ++i) {
-            float x = bounds.position.x + 50.f + (std::rand() % static_cast<int>(bounds.size.x - 100.f));
-            float y = bounds.position.y + 50.f + (std::rand() % static_cast<int>(bounds.size.y - 100.f));
+            float x = bounds.position.x + 50.f + util::randomFloat(0.f, bounds.size.x - 100.f);
+            float y = bounds.position.y + 50.f + util::randomFloat(0.f, bounds.size.y - 100.f);
 
             // Randomly choose enemy type
-            EntityFactory::EnemyType type = (std::rand() % 3 == 0)
+            EntityFactory::EnemyType type = util::randomChance(1.f / 3.f)
                 ? EntityFactory::EnemyType::Bat
                 : EntityFactory::EnemyType::Slime;
 
@@ -198,7 +199,7 @@ private:
 
     void onEnemyDied(const EnemyDiedEvent& e) {
         // 30% chance to spawn health pickup
-        if (std::rand() % 100 < 30) {
+        if (util::randomChance(0.3f)) {
             // Note: We can't spawn here directly since we don't have EntityManager reference
             // The Playing state will handle this via event subscription
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,6 @@
 #include "Application.hpp"
-#include <cstdlib>
-#include <ctime>
 
 int main() {
-    std::srand(static_cast<unsigned>(std::time(nullptr)));
-
     Application app;
     app.run();
 

--- a/src/states/GameOverState.cpp
+++ b/src/states/GameOverState.cpp
@@ -66,7 +66,7 @@ void GameOverState::render(sf::RenderWindow& window) {
 
     // Update buttons with mouse position
     for (auto& button : buttons) {
-        button.update(mousePos, 0.016f);
+        button.update(mousePos, ASSUMED_DT);
     }
 
     // Box background

--- a/src/states/GameOverState.hpp
+++ b/src/states/GameOverState.hpp
@@ -25,6 +25,9 @@ public:
 private:
     void setupUI();
 
+    // Assumed delta time for button animations when actual dt unavailable in render
+    static constexpr float ASSUMED_DT = 1.f / 60.f;
+
     sf::Vector2f windowSize;
     RunState stats;
 

--- a/src/states/MainMenuState.cpp
+++ b/src/states/MainMenuState.cpp
@@ -42,8 +42,8 @@ void MainMenuState::setupUI() {
     }
 }
 
-void MainMenuState::update(float dt) {
-    pulseTimer += dt;
+void MainMenuState::update(float /*dt*/) {
+    // No-op: menu state doesn't need time-based updates
 }
 
 void MainMenuState::render(sf::RenderWindow& window) {
@@ -55,7 +55,7 @@ void MainMenuState::render(sf::RenderWindow& window) {
 
     // Update buttons with mouse position
     for (auto& button : buttons) {
-        button.update(mousePos, 0.016f);
+        button.update(mousePos, ASSUMED_DT);
     }
 
     // Draw title

--- a/src/states/MainMenuState.hpp
+++ b/src/states/MainMenuState.hpp
@@ -24,8 +24,10 @@ public:
 private:
     void setupUI();
 
+    // Assumed delta time for button animations when actual dt unavailable in render
+    static constexpr float ASSUMED_DT = 1.f / 60.f;  // ~0.016f at 60 FPS
+
     sf::Vector2f windowSize;
-    float pulseTimer = 0.f;
 
     std::optional<sf::Text> titleLine1;
     std::optional<sf::Text> titleLine2;

--- a/src/states/PausedState.cpp
+++ b/src/states/PausedState.cpp
@@ -51,7 +51,7 @@ void PausedState::render(sf::RenderWindow& window) {
 
     // Update buttons with mouse position
     for (auto& button : buttons) {
-        button.update(mousePos, 0.016f);
+        button.update(mousePos, ASSUMED_DT);
     }
 
     // Pause box background

--- a/src/states/PausedState.hpp
+++ b/src/states/PausedState.hpp
@@ -24,6 +24,9 @@ public:
 private:
     void setupUI();
 
+    // Assumed delta time for button animations when actual dt unavailable in render
+    static constexpr float ASSUMED_DT = 1.f / 60.f;
+
     sf::Vector2f windowSize;
     std::optional<sf::Text> title;
     std::vector<MenuButton> buttons;

--- a/src/states/PlayingState.cpp
+++ b/src/states/PlayingState.cpp
@@ -3,6 +3,7 @@
 #include "VictoryState.hpp"
 #include "PausedState.hpp"
 #include "../core/StateManager.hpp"
+#include "../util/Random.hpp"
 
 PlayingState::PlayingState(sf::Vector2f windowSize)
     : windowSize(windowSize) {}
@@ -30,7 +31,7 @@ void PlayingState::setupEventHandlers() {
         runState.enemiesKilled++;
 
         // 30% chance to spawn health pickup
-        if (std::rand() % 100 < 30) {
+        if (util::randomChance(0.3f)) {
             EntityFactory::createHealthPickup(entities, {e.x, e.y});
         }
     });
@@ -80,14 +81,14 @@ void PlayingState::enterRoom() {
     if (room->getType() == RoomType::Combat && !room->isCleared()) {
         int minEnemies = 2 + runState.currentFloor / 2;
         int maxEnemies = 4 + runState.currentFloor / 2;
-        int count = minEnemies + (std::rand() % (maxEnemies - minEnemies + 1));
+        int count = util::randomInt(minEnemies, maxEnemies);
 
         const auto& bounds = room->getBounds();
         for (int i = 0; i < count; ++i) {
-            float x = bounds.position.x + 50.f + (std::rand() % static_cast<int>(bounds.size.x - 100.f));
-            float y = bounds.position.y + 50.f + (std::rand() % static_cast<int>(bounds.size.y - 100.f));
+            float x = bounds.position.x + 50.f + util::randomFloat(0.f, bounds.size.x - 100.f);
+            float y = bounds.position.y + 50.f + util::randomFloat(0.f, bounds.size.y - 100.f);
 
-            EntityFactory::EnemyType type = (std::rand() % 3 == 0)
+            EntityFactory::EnemyType type = util::randomChance(1.f / 3.f)
                 ? EntityFactory::EnemyType::Bat
                 : EntityFactory::EnemyType::Slime;
 
@@ -172,12 +173,13 @@ void PlayingState::checkRoomTransitions() {
 
 void PlayingState::transitionToRoom(int targetId, Direction fromDir) {
     // Calculate opposite direction for spawn
-    Direction opposite;
+    Direction opposite = Direction::South;  // Default initialization
     switch (fromDir) {
         case Direction::North: opposite = Direction::South; break;
         case Direction::South: opposite = Direction::North; break;
         case Direction::East:  opposite = Direction::West; break;
         case Direction::West:  opposite = Direction::East; break;
+        default: break;  // All cases covered, but satisfies -Wswitch-default
     }
 
     transitioning = true;

--- a/src/states/VictoryState.cpp
+++ b/src/states/VictoryState.cpp
@@ -76,7 +76,7 @@ void VictoryState::render(sf::RenderWindow& window) {
 
     // Update buttons with mouse position
     for (auto& button : buttons) {
-        button.update(mousePos, 0.016f);
+        button.update(mousePos, ASSUMED_DT);
     }
 
     // Box background

--- a/src/states/VictoryState.hpp
+++ b/src/states/VictoryState.hpp
@@ -25,6 +25,9 @@ public:
 private:
     void setupUI();
 
+    // Assumed delta time for button animations when actual dt unavailable in render
+    static constexpr float ASSUMED_DT = 1.f / 60.f;
+
     sf::Vector2f windowSize;
     RunState stats;
     float celebrationTimer = 0.f;

--- a/src/util/Random.hpp
+++ b/src/util/Random.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <random>
+
+namespace util {
+
+// Thread-local random number generator using Mersenne Twister
+inline std::mt19937& getRng() {
+    static thread_local std::mt19937 rng{std::random_device{}()};
+    return rng;
+}
+
+// Generate random int in range [min, max] (inclusive)
+inline int randomInt(int min, int max) {
+    std::uniform_int_distribution<int> dist(min, max);
+    return dist(getRng());
+}
+
+// Generate random float in range [min, max)
+inline float randomFloat(float min, float max) {
+    std::uniform_real_distribution<float> dist(min, max);
+    return dist(getRng());
+}
+
+// Generate random bool with given probability of true (0.0 to 1.0)
+inline bool randomChance(float probability) {
+    std::uniform_real_distribution<float> dist(0.f, 1.f);
+    return dist(getRng()) < probability;
+}
+
+} // namespace util


### PR DESCRIPTION
## Summary

- **Issue #5**: Replace all `std::rand()` with modern C++17 `<random>` library using a new `util::Random.hpp` utility
- **Issue #6**: Add default case to direction switch statement for defensive coding
- **Issue #7**: Extract `0.016f` magic number to named `ASSUMED_DT` constant across all state classes
- **Issue #8**: Remove unused `pulseTimer` member from MainMenuState

## Changes

### New Files
- `src/util/Random.hpp` - Thread-safe random utilities using `std::mt19937`:
  - `util::randomInt(min, max)` - inclusive integer range
  - `util::randomFloat(min, max)` - float range
  - `util::randomChance(probability)` - boolean with given probability

### Modified Files
- `Systems.hpp` - Use util::randomFloat for AI wandering
- `Floor.hpp` - Use util::randomInt for room generation
- `Room.hpp` - Use util random functions for enemy spawning
- `PlayingState.cpp` - Use util random functions, add switch default
- `MainMenuState.*` - Remove pulseTimer, add ASSUMED_DT constant
- `PausedState.*` - Add ASSUMED_DT constant
- `GameOverState.*` - Add ASSUMED_DT constant
- `VictoryState.*` - Add ASSUMED_DT constant

## Test plan

- [x] Build passes
- [x] All 265 assertions in 91 test cases pass
- [x] Random behavior preserved (same probability distributions)

Fixes #5, Fixes #6, Fixes #7, Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)